### PR TITLE
fix(morsel): Move morsel's spin.toml to root directory

### DIFF
--- a/serve.sh
+++ b/serve.sh
@@ -8,6 +8,6 @@ trap 'kill $(jobs -p)' EXIT
 spin up --log-dir ./log --file spin.toml &
 
 # Start Redis handler
-spin up --log-dir ./log --file morsel_event/spin.toml &
+spin up --log-dir ./log --file spin-morsel.toml &
 
 wait

--- a/spin-morsel.toml
+++ b/spin-morsel.toml
@@ -1,0 +1,11 @@
+spin_version = "1"
+name = "finicky-whiskers-redis"
+trigger = { type = "redis", address = "redis://localhost:6379" }
+version = "0.1.0"
+
+[[component]]
+id = "morsel-event"
+source = "components/morsel_event.wasm"
+environment = { REDIS_ADDRESS = "redis://localhost:6379" }
+[component.trigger]
+channel = "fw-tally"


### PR DESCRIPTION
morsel_event is moved to ./components when compiled.  The spin.toml
can't reference a module in a parent directory.