### PR TITLE
fix: Remove waiting for redis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,6 @@ jobs:
 
       - name: Test site
         env:
-          WAIT_FOR_REDIS: false
           TIMEOUT: 1m
         run: |
           make test-server

--- a/serve.sh
+++ b/serve.sh
@@ -1,12 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Wait for Redis
-[[ "${WAIT_FOR_REDIS:-true}" == "true" ]] && \
-  if ! timeout 10s bash -c "until echo PING | nc localhost 6379 &>/dev/null; do sleep 1; done"; then
-    echo "Redis is unreachable or not healthy" && exit 1
-  fi
-
 # IP address and port to listen on
 SPIN_ADDRESS="${SPIN_ADDRESS:-127.0.0.1:3000}"
 


### PR DESCRIPTION
This removes waiting for redis from the serve script.

The `nc` command has two flavors BSD and GNU.  They have very different options.  This removes the functionally until have a better solution.