### PR TITLE
Fix bug where module counter needs reset.

### DIFF
--- a/site/assets/js/game.js
+++ b/site/assets/js/game.js
@@ -7,6 +7,12 @@ var fetchedHighscore = 0;
 var buttonPresses = 0;
 var timerTicks = 0;
 
+function resetModCounter() {
+  fetchedHighscore = 0;
+  buttonPresses = 0;
+  timerTicks = 0;
+}
+
 // start screen
 document.querySelectorAll('.modal-button').forEach(function (el) {
   el.addEventListener('click', function () {
@@ -115,6 +121,7 @@ function setup() {
   $("#highScores").hide();
   document.getElementById("highScoresList").textContent = ''
   highScore = ""
+  resetModCounter()
   // get the data
   // https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch
   fetch('/session').then(


### PR DESCRIPTION
This resets the module counter. The first count that shows on a game start should be 26 (25 assets and one click to session)

Signed-off-by: Matt Butcher <matt.butcher@fermyon.com>