### PR TITLE
Bump Spin in github workflow for build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,8 @@ jobs:
 
       - name: Install spin
         run: |
-          curl -LOs https://github.com/fermyon/spin/releases/download/v1.1.0/spin-v1.1.0-linux-amd64.tar.gz
-          tar zxvf spin-v1.1.0-linux-amd64.tar.gz
+          curl -LOs https://github.com/fermyon/spin/releases/download/v1.3.0/spin-v1.3.0-linux-amd64.tar.gz
+          tar zxvf spin-v1.3.0-linux-amd64.tar.gz
           mv spin /usr/local/bin
 
       - name: Build


### PR DESCRIPTION
Bumping version of Spin used to build. I don't think this matters all that much so we can take it or leave or if you have a strong opinion @rajatjindal .