### PR TITLE
chore(.github): bump artifact actions to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
           make test-server
 
       - name: Archive app artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: app
           path: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
     needs: build
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: app
           path: "${{ github.workspace }}"


### PR DESCRIPTION
- Bumps the artifact actions to v4 per https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/