### PR TITLE
chore(.github): pin go version for tinygo compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,10 @@ jobs:
           unzip wasi-vfs-cli-x86_64-unknown-linux-gnu.zip
           mv wasi-vfs /usr/local/bin
 
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'redirect/go.mod'
+
       - name: Install tinygo
         run: |
           wget https://github.com/tinygo-org/tinygo/releases/download/v0.27.0/tinygo_0.27.0_amd64.deb


### PR DESCRIPTION
- Pins go version to match [redirect's go.mod file](https://github.com/fermyon/finicky-whiskers/blob/main/redirect/go.mod)

Fix for [recent build failure](https://github.com/fermyon/finicky-whiskers/actions/runs/10722418743/job/29733283183?pr=93): `error: requires go version 1.18 through 1.20, got go1.21`